### PR TITLE
Hotfix: Add bucket context with creds to get file operation

### DIFF
--- a/core/textile/client/client_file.go
+++ b/core/textile/client/client_file.go
@@ -2,12 +2,17 @@ package client
 
 import (
 	"context"
-	"github.com/FleekHQ/space-poc/log"
 	"io"
+
+	"github.com/FleekHQ/space-poc/log"
 )
 
 // GetFile pulls path from bucket writing it to writer if it's a file.
 func (tc *textileClient) GetFile(ctx context.Context, bucketKey string, path string, w io.Writer) error {
+	ctx, _, err := tc.GetBucketContext(defaultPersonalBucketSlug)
+	if err != nil {
+		return err
+	}
 	if err := tc.buckets.PullPath(ctx, bucketKey, path, w); err != nil {
 		log.Error("error in GetFile from textile client", err)
 		return err
@@ -15,4 +20,3 @@ func (tc *textileClient) GetFile(ctx context.Context, bucketKey string, path str
 
 	return nil
 }
-


### PR DESCRIPTION
Not sure if this is really best practice, since it discards the context being passed. Pushing this as a hotfix so we can unblock testing. But will do a better refactor later: make both the context creation functions also take in an existing context and use that if supplied.