### PR TITLE
Make Textile creds ctx creators take in an existing context

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,13 +2,14 @@ package app
 
 import (
 	"context"
-	"github.com/FleekHQ/space-poc/core/env"
-	"github.com/FleekHQ/space-poc/core/space"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/FleekHQ/space-poc/core/env"
+	"github.com/FleekHQ/space-poc/core/space"
 
 	"github.com/FleekHQ/space-poc/core/sync"
 
@@ -49,7 +50,6 @@ func Start(ctx context.Context, cfg config.Config, env env.SpaceEnv) {
 
 	<-waitForStore
 
-
 	watcher, err := w.New(w.WithPaths(cfg.GetString(config.SpaceFolderPath, "")))
 	if err != nil {
 		log.Fatal(err)
@@ -59,7 +59,7 @@ func Start(ctx context.Context, cfg config.Config, env env.SpaceEnv) {
 	bootstrapReady := make(chan bool)
 	textileClient := tc.New(store)
 	g.Go(func() error {
-		err := textileClient.StartAndBootstrap()
+		err := textileClient.StartAndBootstrap(ctx)
 		bootstrapReady <- true
 		return err
 	})

--- a/core/space/services/services_fs.go
+++ b/core/space/services/services_fs.go
@@ -60,7 +60,7 @@ func (s *Space) listDirAtPath(
 }
 
 func (s *Space) ListDir(ctx context.Context) ([]domain.FileInfo, error) {
-	buckets, err := s.tc.ListBuckets()
+	buckets, err := s.tc.ListBuckets(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (s *Space) GetPathInfo(ctx context.Context, path string) (domain.FileInfo, 
 
 func (s *Space) OpenFile(ctx context.Context, path string, bucketSlug string) (domain.OpenFileInfo, error) {
 	// TODO : handle bucketslug for multiple buckets. For now default to personal bucket
-	key, err := s.getDefaultBucketKey()
+	key, err := s.getDefaultBucketKey(ctx)
 	if err != nil {
 		return domain.OpenFileInfo{}, err
 	}
@@ -114,8 +114,8 @@ func (s *Space) OpenFile(ctx context.Context, path string, bucketSlug string) (d
 	}, nil
 }
 
-func (s *Space) getDefaultBucketKey() (string, error) {
-	buckets, err := s.tc.ListBuckets()
+func (s *Space) getDefaultBucketKey(ctx context.Context) (string, error) {
+	buckets, err := s.tc.ListBuckets(ctx)
 	if err != nil {
 		log.Error("error while fetching buckets in OpenFile", err)
 		return "", err
@@ -129,7 +129,7 @@ func (s *Space) getDefaultBucketKey() (string, error) {
 }
 
 func (s *Space) CreateFolder(ctx context.Context, path string) error {
-	key, err := s.getDefaultBucketKey()
+	key, err := s.getDefaultBucketKey(ctx)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func (s *Space) createFolder(ctx context.Context, path string, key string) error
 
 func (s *Space) AddItems(ctx context.Context, sourcePaths []string, targetPath string) error {
 	// TODO: add support for bucket slug
-	key, err := s.getDefaultBucketKey()
+	key, err := s.getDefaultBucketKey(ctx)
 	if err != nil {
 		return err
 	}

--- a/core/sync/sync.go
+++ b/core/sync/sync.go
@@ -47,7 +47,7 @@ func New(
 
 // Starts the folder watcher and the textile watcher.
 func (bs *BucketSynchronizer) Start(ctx context.Context) error {
-	buckets, err := bs.textileClient.ListBuckets()
+	buckets, err := bs.textileClient.ListBuckets(ctx)
 	if err != nil {
 		return err
 	}

--- a/core/textile/client/client_file.go
+++ b/core/textile/client/client_file.go
@@ -9,7 +9,7 @@ import (
 
 // GetFile pulls path from bucket writing it to writer if it's a file.
 func (tc *textileClient) GetFile(ctx context.Context, bucketKey string, path string, w io.Writer) error {
-	ctx, _, err := tc.GetBucketContext(defaultPersonalBucketSlug)
+	ctx, _, err := tc.GetBucketContext(ctx, defaultPersonalBucketSlug)
 	if err != nil {
 		return err
 	}

--- a/core/textile/client/crud.go
+++ b/core/textile/client/crud.go
@@ -18,7 +18,7 @@ func (tc *textileClient) UploadFile(
 	path string,
 	reader io.Reader,
 ) (result path.Resolved, root path.Path, err error) {
-	ctx, _, err = tc.GetBucketContext(defaultPersonalBucketSlug)
+	ctx, _, err = tc.GetBucketContext(ctx, defaultPersonalBucketSlug)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -33,7 +33,7 @@ func (tc *textileClient) CreateDirectory(
 	bucketKey string,
 	path string,
 ) (result path.Resolved, root path.Path, err error) {
-	ctx, _, err = tc.GetBucketContext(defaultPersonalBucketSlug)
+	ctx, _, err = tc.GetBucketContext(ctx, defaultPersonalBucketSlug)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -48,7 +48,7 @@ func (tc *textileClient) ListDirectory(
 	bucketKey string,
 	path string,
 ) (*TextileDirEntries, error) {
-	ctx, _, err := tc.GetBucketContext(defaultPersonalBucketSlug)
+	ctx, _, err := tc.GetBucketContext(ctx, defaultPersonalBucketSlug)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (tc *textileClient) DeleteDirOrFile(
 	bucketKey string,
 	path string,
 ) (path.Resolved, error) {
-	ctx, _, err := tc.GetBucketContext(defaultPersonalBucketSlug)
+	ctx, _, err := tc.GetBucketContext(ctx, defaultPersonalBucketSlug)
 	if err != nil {
 		return nil, err
 	}

--- a/core/textile/listener/listener.go
+++ b/core/textile/listener/listener.go
@@ -28,8 +28,6 @@ type textileThreadListener struct {
 	handlers           []handler.EventHandler
 }
 
-
-
 func New(textileClient textile.Client, bucketSlug string) ThreadListener {
 	return &textileThreadListener{
 		bucketSlug:    bucketSlug,
@@ -44,7 +42,7 @@ func (tl *textileThreadListener) Listen(ctx context.Context) error {
 	var dbID *thread.ID
 	var err error
 
-	if bucketCtx, dbID, err = tl.textileClient.GetBucketContext(tl.bucketSlug); err != nil {
+	if bucketCtx, dbID, err = tl.textileClient.GetBucketContext(ctx, tl.bucketSlug); err != nil {
 		return err
 	}
 
@@ -150,4 +148,3 @@ func (tl *textileThreadListener) RegisterHandler(handler handler.EventHandler) {
 	defer tl.publishLock.Unlock()
 	tl.handlers = append(tl.handlers, handler)
 }
-


### PR DESCRIPTION
### Change Log
* Updated base context creation helpers to take in an optional ctx variable
* Updated Textile client helpers to pass through ctx

Right now we have the single context being shared every where so things like Done signal are handled. Maybe for now this is okay and in the future we can design top down parallel contexts and how they interact if needed.