### PR TITLE
add profile debugging to main.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 .env
 space.json
 bin
+
+debug/

--- a/README.md
+++ b/README.md
@@ -61,4 +61,15 @@ Binary should run in a folder with a space.json config file with the following s
 If you still have issues, try setting the env var SPACE_APP_DIR
 `export SPACE_APP_DIR=/path/to/the/space/binary`
 
+## Debugging Space Binary
+The following flags can be run with the binary to output profiling files for debugging. 
+Flags support a full path to a file.
+`-cpuprofile cpu.prof -memprofile mem.prof`
+
+By default, the binary runs in debug mode (this may change after release) and it boots a pprof
+server in localhost:6060. See docs how to interact with pprof server here: https://github.com/google/pprof/blob/master/doc/README.md
+
+To disable debug mode add this flag to binary arguments
+`-debug=false`
+
 

--- a/cmd/space-poc/main.go
+++ b/cmd/space-poc/main.go
@@ -3,15 +3,49 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"github.com/FleekHQ/space-poc/app"
 	"github.com/FleekHQ/space-poc/config"
 	"github.com/FleekHQ/space-poc/core/env"
-	"github.com/FleekHQ/space-poc/log"
+	spacelog "github.com/FleekHQ/space-poc/log"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
+	_ "net/http/pprof"
+)
+
+var (
+	cpuprofile = flag.String("cpuprofile", "", "write cpu profile to `file`")
+	memprofile = flag.String("memprofile", "", "write memory profile to `file`")
+	debugMode  = flag.Bool("debug", true, "run daemon with debug mode for profiling")
 )
 
 func main() {
 	// flags
 	flag.Parse()
+
+	// CPU profiling
+	if *debugMode == true {
+		fmt.Println("DEBUG: running daemon with profiler on localhost:6060..")
+		go func() {
+			fmt.Println(http.ListenAndServe("localhost:6060", nil))
+		}()
+	}
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal("could not create CPU profile: ", err)
+		}
+		defer f.Close() // error handling omitted for example
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal("could not start CPU profile: ", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
 
 	// env
 	env := env.New()
@@ -20,9 +54,21 @@ func main() {
 	cfg := config.New(env)
 
 	// setup logger
-	log.New(env)
+	spacelog.New(env)
 	// setup context
 	ctx := context.Background()
 
 	app.Start(ctx, cfg, env)
+
+	if *memprofile != "" {
+		f, err := os.Create(*memprofile)
+		if err != nil {
+			log.Fatal("could not create memory profile: ", err)
+		}
+		defer f.Close() // error handling omitted for example
+		runtime.GC()    // get up-to-date statistics
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			log.Fatal("could not write memory profile: ", err)
+		}
+	}
 }


### PR DESCRIPTION
Related card:
https://app.clubhouse.io/terminalsystems/story/16670/daemon-stops-working-and-consumes-a-lot-of-cpu-after-a-while

Change Log:
* adds profiling tools to daemon to help research performance issues in the space app