### PR TITLE
possible fix for high CPU usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # vendor/
 
 .idea/
+debug/
 
 .env
 space.json

--- a/core/textile/listener.go
+++ b/core/textile/listener.go
@@ -57,6 +57,10 @@ func (tl *textileThreadListener) Listen(ctx context.Context) error {
 	}
 
 	channel, err := threads.Listen(bucketCtx, *dbID, []threadsc.ListenOption{opt})
+	if err != nil {
+		log.Printf("error on threads.listen")
+		return err
+	}
 
 	tl.setToStarted()
 
@@ -64,6 +68,7 @@ func (tl *textileThreadListener) Listen(ctx context.Context) error {
 		log.Debug("received from channel!!!!")
 		instance := &BucketData{}
 		if val.Err != nil {
+			log.Printf("error from threads event " + val.Err.Error())
 			log.Error("error getting threadsc listener event", err)
 			return
 		}
@@ -87,6 +92,9 @@ func (tl *textileThreadListener) Listen(ctx context.Context) error {
 			case val, ok := <-channel:
 				if ok {
 					listenerEventHandler(val)
+				} else {
+					tl.Close()
+					return
 				}
 			}
 		}


### PR DESCRIPTION
NOTE: after testing with the profile analysis, i think we need to handle when the channel is closed by threads library to avoid being stuck on those go routines in an infinite loop. 

We still need to monitor the app and CPU is something else pops up, since its hard to replicate given that the usually could be related to threads side.