### PR TITLE
add default values config

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime"
@@ -19,19 +17,8 @@ const (
 	executableName = "space"
 	binaryName     = "space-poc"
 	downloadURL    = "https://github.com/FleekHQ/space-poc/releases/download/"
-	spaceJsonName  = "space.json"
 )
 
-type defaultSpaceJson struct {
-	TextileHubTarget     string `json:"textileHubTarget"`
-	TextileThreadsTarget string `json:"textileThreadsTarget"`
-	RPCPort              int    `json:"rpcPort"`
-	StorePath            string `json:"storePath"`
-}
-
-type defaultJson struct {
-	Space defaultSpaceJson `json:"space"`
-}
 
 type WriteCounter struct {
 	Total uint64
@@ -84,26 +71,9 @@ func main() {
 	err = os.Chmod(executablePath, 0755)
 	checkErr(err)
 
-	fmt.Println("Generating default config file")
-	spaceJson := defaultSpaceJson{
-		TextileHubTarget:     "textile-hub-dev.fleek.co:3006",
-		TextileThreadsTarget: "textile-hub-dev.fleek.co:3006",
-		RPCPort:              9999,
-		StorePath:            "~/.fleek-space",
-	}
-
-	finalJson := defaultJson{
-		Space: spaceJson,
-	}
-
-	jsonPath := wd + "/" + spaceJsonName
-	marshalled, err := json.MarshalIndent(finalJson, "", "  ")
-	checkErr(err)
-
-	err = ioutil.WriteFile(jsonPath, marshalled, 0644)
-	checkErr(err)
-
-	fmt.Println("Default config file generated")
+	// Uncomment if we need to use config JSON
+	//err = config.CreateConfigJson()
+	//checkErr(err)
 
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("\nEnter your Textile User Key> ")

--- a/cmd/space-poc/main.go
+++ b/cmd/space-poc/main.go
@@ -52,7 +52,7 @@ func main() {
 	env := env.New()
 
 	// load configs
-	cfg := config.New(env)
+	cfg := config.NewMap(env)
 
 	// setup logger
 	spacelog.New(env)

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,6 @@ package config
 
 import (
 	"errors"
-	"fmt"
-	"os"
-
-	"github.com/FleekHQ/space-poc/core/env"
-	"github.com/FleekHQ/space-poc/log"
-	"github.com/creamdog/gonfig"
 )
 
 const (
@@ -31,60 +25,4 @@ type Config interface {
 	GetInt(key string, defaultValue interface{}) int
 }
 
-// standardConfig implements Config
-// It loads its config information from the space.json file
-type standardConfig struct {
-	cfg gonfig.Gonfig
-}
 
-func New(env env.SpaceEnv) Config {
-	wd := env.WorkingFolder()
-	f, err := os.Open(wd + "/" + JsonConfigFileName)
-	if err != nil {
-		// TODO: this may turn into a fatal panic error
-		log.Info("could not find space.json file in " + wd + ", using defaults")
-	}
-
-	defer f.Close()
-	config, err := gonfig.FromJson(f)
-	if err != nil {
-		log.Info("could not read space.json file, using defaults")
-	}
-
-	c := standardConfig{
-		cfg: config,
-	}
-
-	return c
-}
-
-// Gets the configuration value given a path in the json config file
-// defaults to empty value if non is found and just logs errors
-func (c standardConfig) GetString(key string, defaultValue interface{}) string {
-	if c.cfg == nil {
-		return ""
-	}
-	v, err := c.cfg.GetString(key, defaultValue)
-	if err != nil {
-		log.Error(fmt.Sprintf("error getting key %s from config", key), err)
-		return ""
-	}
-	log.Debug("Getting conf " + key + ": " + v)
-
-	return v
-}
-
-// Gets the configuration value given a path in the json config file
-// defaults to empty value if non is found and just logs errors
-func (c standardConfig) GetInt(key string, defaultValue interface{}) int {
-	if c.cfg == nil {
-		return 0
-	}
-	v, err := c.cfg.GetInt(key, defaultValue)
-	if err != nil {
-		log.Error(fmt.Sprintf("error getting key %s from config", key), err)
-		return 0
-	}
-
-	return v
-}

--- a/config/json_config.go
+++ b/config/json_config.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/FleekHQ/space-poc/core/env"
+	"github.com/FleekHQ/space-poc/log"
+	"github.com/creamdog/gonfig"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// standardConfig implements Config
+// It loads its config information from the space.json file
+type jsonConfig struct {
+	cfg gonfig.Gonfig
+}
+
+
+type defaultSpaceJson struct {
+	TextileHubTarget     string `json:"textileHubTarget"`
+	TextileThreadsTarget string `json:"textileThreadsTarget"`
+	RPCPort              int    `json:"rpcPort"`
+	StorePath            string `json:"storePath"`
+}
+
+type defaultJson struct {
+	Space defaultSpaceJson `json:"space"`
+}
+
+// Deprecated for the default values config
+func NewJson(env env.SpaceEnv) Config {
+	wd := env.WorkingFolder()
+	f, err := os.Open(wd + "/" + JsonConfigFileName)
+	if err != nil {
+		// TODO: this may turn into a fatal panic error
+		log.Info("could not find space.json file in " + wd + ", using defaults")
+	}
+
+	defer f.Close()
+	config, err := gonfig.FromJson(f)
+	if err != nil {
+		log.Info("could not read space.json file, using defaults")
+	}
+
+	c := jsonConfig{
+		cfg: config,
+	}
+
+	return c
+}
+
+// Gets the configuration value given a path in the json config file
+// defaults to empty value if non is found and just logs errors
+func (c jsonConfig) GetString(key string, defaultValue interface{}) string {
+	if c.cfg == nil {
+		return ""
+	}
+	v, err := c.cfg.GetString(key, defaultValue)
+	if err != nil {
+		log.Error(fmt.Sprintf("error getting key %s from config", key), err)
+		return ""
+	}
+	log.Debug("Getting conf " + key + ": " + v)
+
+	return v
+}
+
+// Gets the configuration value given a path in the json config file
+// defaults to empty value if non is found and just logs errors
+func (c jsonConfig) GetInt(key string, defaultValue interface{}) int {
+	if c.cfg == nil {
+		return 0
+	}
+	v, err := c.cfg.GetInt(key, defaultValue)
+	if err != nil {
+		log.Error(fmt.Sprintf("error getting key %s from config", key), err)
+		return 0
+	}
+
+	return v
+}
+
+func CreateConfigJson() error {
+	fmt.Println("Generating default config file")
+	spaceJson := defaultSpaceJson{
+		TextileHubTarget:     "textile-hub-dev.fleek.co:3006",
+		TextileThreadsTarget: "textile-hub-dev.fleek.co:3006",
+		RPCPort:              9999,
+		StorePath:            "~/.fleek-space",
+	}
+
+	finalJson := defaultJson{
+		Space: spaceJson,
+	}
+
+	currExecutablePath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	pathSegments := strings.Split(currExecutablePath, "/")
+	wd := strings.Join(pathSegments[:len(pathSegments)-1], "/")
+
+	jsonPath := wd + "/" + JsonConfigFileName
+	marshalled, err := json.MarshalIndent(finalJson, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(jsonPath, marshalled, 0644)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Default config file generated")
+
+	return nil
+}

--- a/config/map_config.go
+++ b/config/map_config.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"github.com/FleekHQ/space-poc/core/env"
+)
+
+type mapConfig struct {
+	configStr map[string]string
+	configInt map[string]int
+}
+
+func NewMap(env env.SpaceEnv) Config {
+	configStr := make(map[string]string)
+	configInt := make(map[string]int)
+
+	// default values
+	configStr[SpaceStorePath] = "~/.fleek-space"
+	configStr[TextileHubTarget] = "textile-hub-dev.fleek.co:3006"
+	configStr[TextileThreadsTarget] = "textile-hub-dev.fleek.co:3006"
+	configStr[MountFuseDrive] = "false"
+	configStr[FuseMountPath] = "~/"
+	configStr[FuseDriveName] = "FleekSpace"
+	configInt[SpaceServerPort] = 9999
+
+	c := mapConfig{
+		configStr: configStr,
+		configInt: configInt,
+	}
+
+	return c
+}
+
+func (m mapConfig) GetString(key string, defaultValue interface{}) string {
+	if val, exists := m.configStr[key]; exists {
+		return val
+	}
+
+	if stringValue, ok := defaultValue.(string); ok {
+		return stringValue
+	}
+
+	return ""
+}
+
+func (m mapConfig) GetInt(key string, defaultValue interface{}) int {
+	if val, exists := m.configInt[key]; exists {
+		return val
+	}
+
+	if intVal, ok := defaultValue.(int); ok {
+		return intVal
+	}
+
+	return 0
+}

--- a/core/env/env.go
+++ b/core/env/env.go
@@ -4,8 +4,6 @@ import (
 	syslog "log"
 	"os"
 	"strings"
-
-	"github.com/joho/godotenv"
 )
 
 const (
@@ -19,19 +17,11 @@ type SpaceEnv interface {
 	LogLevel() string
 }
 
-type spaceEnv struct {
+type defaultEnv struct {
+
 }
 
-func New() SpaceEnv {
-	err := godotenv.Load()
-	if err != nil {
-		syslog.Println("Error loading .env file. Using defaults")
-	}
-
-	return spaceEnv{}
-}
-
-func (s spaceEnv) CurrentFolder() (string, error) {
+func (d defaultEnv) CurrentFolder() (string, error) {
 	path, err := os.Executable()
 	if err != nil {
 		return "", err
@@ -43,27 +33,21 @@ func (s spaceEnv) CurrentFolder() (string, error) {
 	return wd, nil
 }
 
-func (s spaceEnv) WorkingFolder() string {
-	var wd = os.Getenv(SpaceWorkingDir)
-	// use default
-	if wd == "" {
-		cf, err := s.CurrentFolder()
-		if err != nil {
-			syslog.Fatal("unable to get working folder", err)
-			panic(err)
-		}
-		wd = cf
-	}
 
-	return wd
+func (d defaultEnv) WorkingFolder() string {
+	cf, err := d.CurrentFolder()
+	if err != nil {
+		syslog.Fatal("unable to get working folder", err)
+		panic(err)
+	}
+	return cf
 }
 
-func (s spaceEnv) LogLevel() string {
-	var ll = os.Getenv(LogLevel)
+func (d defaultEnv) LogLevel() string {
+	return "Info"
+}
 
-	if ll == "" {
-		return "Info"
-	}
-
-	return ll
+// TODO: use this one after figuring textile keys
+func NewDefault() SpaceEnv {
+	return defaultEnv{}
 }

--- a/core/env/file_env.go
+++ b/core/env/file_env.go
@@ -1,0 +1,58 @@
+package env
+
+import (
+	"github.com/joho/godotenv"
+	syslog "log"
+	"os"
+	"strings"
+)
+
+type spaceEnv struct {
+}
+
+// Deprecated for default values
+func New() SpaceEnv {
+	err := godotenv.Load()
+	if err != nil {
+		syslog.Println("Error loading .env file. Using defaults")
+	}
+
+	return spaceEnv{}
+}
+
+func (s spaceEnv) CurrentFolder() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	pathSegments := strings.Split(path, "/")
+	wd := strings.Join(pathSegments[:len(pathSegments)-1], "/")
+
+	return wd, nil
+}
+
+func (s spaceEnv) WorkingFolder() string {
+	var wd = os.Getenv(SpaceWorkingDir)
+	// use default
+	if wd == "" {
+		cf, err := s.CurrentFolder()
+		if err != nil {
+			syslog.Fatal("unable to get working folder", err)
+			panic(err)
+		}
+		wd = cf
+	}
+
+	return wd
+}
+
+func (s spaceEnv) LogLevel() string {
+	var ll = os.Getenv(LogLevel)
+
+	if ll == "" {
+		return "Info"
+	}
+
+	return ll
+}


### PR DESCRIPTION
https://app.clubhouse.io/terminalsystems/story/16673/run-without-configuration-env-vars

change Log:
* Adds map backed implementation for config with default values
* Adds default env implementation
* removes JSON config file dependency from daemon and installer
* deprecated Implementation for Json backed config

TODO: move out of .env file by writing textile keys to store in installer and implement env that source from store
