### PR TITLE
add dev mode and better store error checking on startup

### DIFF
--- a/cmd/space-poc/main.go
+++ b/cmd/space-poc/main.go
@@ -22,6 +22,7 @@ var (
 	cpuprofile = flag.String("cpuprofile", "", "write cpu profile to `file`")
 	memprofile = flag.String("memprofile", "", "write memory profile to `file`")
 	debugMode  = flag.Bool("debug", true, "run daemon with debug mode for profiling")
+	devMode    = flag.Bool("dev", false, "run daemon in dev mode to use .env file")
 	ipfsaddr   string
 	mongousr   string
 	mongopw    string
@@ -32,11 +33,14 @@ func main() {
 	// flags
 	flag.Parse()
 
+	log.Printf("INFO: dev mode %v", *devMode)
+
 	cf := &config.Flags{
 		Ipfsaddr:  ipfsaddr,
 		Mongousr:  mongousr,
 		Mongopw:   mongopw,
 		Mongohost: mongohost,
+		DevMode: *devMode == true,
 	}
 
 	// CPU profiling

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Flags struct {
 	Mongousr  string
 	Mongopw   string
 	Mongohost string
+	DevMode   bool
 }
 
 // Config used to fetch config information

--- a/config/map_config.go
+++ b/config/map_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/FleekHQ/space-poc/core/env"
+	"os"
 )
 
 type mapConfig struct {
@@ -9,7 +10,7 @@ type mapConfig struct {
 	configInt map[string]int
 }
 
-func NewMap(env env.SpaceEnv, flags *Flags) Config {
+func NewMap(envVal env.SpaceEnv, flags *Flags) Config {
 	configStr := make(map[string]string)
 	configInt := make(map[string]int)
 
@@ -21,10 +22,17 @@ func NewMap(env env.SpaceEnv, flags *Flags) Config {
 	configStr[FuseMountPath] = "~/"
 	configStr[FuseDriveName] = "FleekSpace"
 	configInt[SpaceServerPort] = 9999
-	configStr[Ipfsaddr] = flags.Ipfsaddr
-	configStr[Mongousr] = flags.Mongousr
-	configStr[Mongopw] = flags.Mongopw
-	configStr[Mongohost] = flags.Mongohost
+	if flags.DevMode {
+		configStr[Ipfsaddr] = os.Getenv(env.IpfsAddr)
+		configStr[Mongousr] = os.Getenv(env.MongoUsr)
+		configStr[Mongopw] = os.Getenv(env.MongoPw)
+		configStr[Mongohost] = os.Getenv(env.MongoHost)
+	} else {
+		configStr[Ipfsaddr] = flags.Ipfsaddr
+		configStr[Mongousr] = flags.Mongousr
+		configStr[Mongopw] = flags.Mongopw
+		configStr[Mongohost] = flags.Mongohost
+	}
 
 	c := mapConfig{
 		configStr: configStr,

--- a/core/env/env.go
+++ b/core/env/env.go
@@ -9,6 +9,10 @@ import (
 const (
 	SpaceWorkingDir = "SPACE_APP_DIR"
 	LogLevel        = "LOG_LEVEL"
+	IpfsAddr        = "IPFS_ADDR"
+	MongoUsr        = "MONGO_USR"
+	MongoPw         = "MONGO_PW"
+	MongoHost       = "MONGO_HOST"
 )
 
 type SpaceEnv interface {
@@ -18,7 +22,6 @@ type SpaceEnv interface {
 }
 
 type defaultEnv struct {
-
 }
 
 func (d defaultEnv) CurrentFolder() (string, error) {
@@ -32,7 +35,6 @@ func (d defaultEnv) CurrentFolder() (string, error) {
 
 	return wd, nil
 }
-
 
 func (d defaultEnv) WorkingFolder() string {
 	cf, err := d.CurrentFolder()

--- a/core/env/file_env.go
+++ b/core/env/file_env.go
@@ -10,7 +10,7 @@ import (
 type spaceEnv struct {
 }
 
-// Deprecated for default values
+// Loads environment from .env file for dev mode
 func New() SpaceEnv {
 	err := godotenv.Load()
 	if err != nil {

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -70,10 +70,14 @@ func (store *store) Open() error {
 	if home, err := homedir.Dir(); err == nil {
 		// If the root directory contains ~, we replace it with the actual home directory
 		rootDir = s.Replace(rootDir, "~", home, -1)
+	} else {
+		return err
 	}
 
 	// We create the directory in case it doesn't exist yet
-	os.MkdirAll(rootDir, os.ModePerm)
+	if err := os.MkdirAll(rootDir, os.ModePerm); err != nil {
+		return err
+	}
 	if db, err := badger.Open(badger.DefaultOptions(rootDir)); err != nil {
 		return err
 	} else {


### PR DESCRIPTION
https://app.clubhouse.io/terminalsystems/story/16814/store-hangs-on-startup

Change Log:
* With this change we can run the space binary with `-dev` flag to use the .env file in development environment
* Fix bugs with error checking on store bootstrap that could hang the daemon boot

